### PR TITLE
Enhancements/group tags by namespace

### DIFF
--- a/api/tags.py
+++ b/api/tags.py
@@ -21,16 +21,20 @@ async def _update_tag(id, body):
         return responses.update(updated_tag.dump())
 
 
-async def search(page, page_size, sort_by, sort_dir, request=None):
-    sort_func = getattr(db, sort_dir)
+async def search(request=None):
     [tags, count] = await asyncio.gather(
-        Tag.query.limit(page_size).offset(
-            page * page_size).order_by(sort_func(sort_by)).gino.all(),
+        Tag.query.gino.all(),
         db.scalar(db.select([db.func.count(Tag.id)]))
     )
 
     tags_dump = [tag.dump() for tag in tags]
-    return responses.search(count, tags_dump)
+    namespaces_list = []
+    ns1 = {}
+    ns1["name"] = "testNamespace"
+    ns1["tags"] = [{"name1": "value1"}, {"name2": "value2"}]
+    namespaces_list.append(ns1)
+
+    return responses.search(count, namespaces_list)
 
 
 async def post(request=None):

--- a/api/tags.py
+++ b/api/tags.py
@@ -27,14 +27,14 @@ async def search(request=None):
         db.scalar(db.select([db.func.count(Tag.id)]))
     )
 
-    tags_dump = [tag.dump() for tag in tags]
-    namespaces_list = []
-    ns1 = {}
-    ns1["name"] = "testNamespace"
-    ns1["tags"] = [{"name1": "value1"}, {"name2": "value2"}]
-    namespaces_list.append(ns1)
+    # tags_dump = [tag.dump() for tag in tags]
+    namespaces_data = {}
+    for tag in tags:
+        if tag.namespace not in namespaces_data:
+            namespaces_data[tag.namespace] = []
+        namespaces_data[tag.namespace].append({tag.name: tag.value})
 
-    return responses.search(count, namespaces_list)
+    return responses.get(namespaces_data)
 
 
 async def post(request=None):

--- a/api/tags.py
+++ b/api/tags.py
@@ -27,7 +27,6 @@ async def search(request=None):
         db.scalar(db.select([db.func.count(Tag.id)]))
     )
 
-    # tags_dump = [tag.dump() for tag in tags]
     namespaces_data = {}
     for tag in tags:
         if tag.namespace not in namespaces_data:

--- a/config.ini
+++ b/config.ini
@@ -11,6 +11,7 @@ db_pool_size = 30
 db_max_overflow = 100
 
 [dev]
+db_host = 172.30.54.240
 
 [test]
 log_level = ERROR

--- a/config.ini
+++ b/config.ini
@@ -11,7 +11,6 @@ db_pool_size = 30
 db_max_overflow = 100
 
 [dev]
-db_host = 172.30.54.240
 
 [test]
 log_level = ERROR

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -12,33 +12,6 @@ paths:
   /tags:
     get:
       description: ''
-      parameters:
-        - name: page
-          in: query
-          description: A page number within the paginated result set.
-          required: false
-          type: integer
-          default: 0
-        - name: page_size
-          in: query
-          description: Size of the page
-          required: false
-          type: integer
-          default: 10
-        - name: sort_by
-          in: query
-          description: Attribute to sort results by
-          required: false
-          type: string
-          default: id
-          enum: [id, name, description, created_at, updated_at]
-        - name: sort_dir
-          in: query
-          description: Direction to sort
-          required: false
-          type: string
-          default: asc
-          enum: [asc, desc]
       responses:
         '200':
           description: 'List tags response'
@@ -50,16 +23,10 @@ paths:
             properties:
               count:
                 type: integer
-              next:
-                type: string
-                format: uri
-              previous:
-                type: string
-                format: uri
               results:
                 type: array
                 items:
-                  $ref: '#/definitions/TagRetrieve'
+                  $ref: '#/definitions/NamespaceRetrieve'
       tags:
         - tags
     post:
@@ -215,6 +182,20 @@ definitions:
       namespace:
         title: Namespace
         type: string
+  NamespaceRetrieve:
+    required:
+      - name
+      - tags
+    type: object
+    properties:
+      name:
+        title: Name
+        type: string
+      tags:
+        title: Tags
+        type: array
+        items:
+          type: object
   TagRetrieve:
     required:
       - id

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -14,19 +14,9 @@ paths:
       description: ''
       responses:
         '200':
-          description: 'List tags response'
+          description: 'Group tags by namespace response'
           schema:
-            required:
-              - count
-              - results
             type: object
-            properties:
-              count:
-                type: integer
-              results:
-                type: array
-                items:
-                  $ref: '#/definitions/NamespaceRetrieve'
       tags:
         - tags
     post:
@@ -182,20 +172,6 @@ definitions:
       namespace:
         title: Namespace
         type: string
-  NamespaceRetrieve:
-    required:
-      - name
-      - tags
-    type: object
-    properties:
-      name:
-        title: Name
-        type: string
-      tags:
-        title: Tags
-        type: array
-        items:
-          type: object
   TagRetrieve:
     required:
       - id


### PR DESCRIPTION
Changes the Search (i.e. GET /tags endpoint) to display the name and value of all tags in the db, grouped by Namespace. I'm wondering if there's a more elegant way to group by namespace on the DB query level, but I can't figure it out with the Gino docs at the moment.